### PR TITLE
Position and jump fixes

### DIFF
--- a/Chraft/Client.Recv.cs
+++ b/Chraft/Client.Recv.cs
@@ -123,7 +123,6 @@ namespace Chraft
                                     {
                                         // Make sure that we don't think we have fallen onto the respawn
                                         _lastGroundY = -1;
-                                        _beginInAirY = -1;
                                     }
                                 }
                             }
@@ -134,6 +133,8 @@ namespace Chraft
 #endif
                             }
                         }
+
+                        _beginInAirY = -1;
                     }
                 }
             }
@@ -980,7 +981,7 @@ namespace Chraft
 
         private void PacketHandler_PlayerPositionRotation(object sender, PacketEventArgs<PlayerPositionRotationPacket> e)
         {
-            this.MoveTo(e.Packet.X, e.Packet.Y, e.Packet.Z, e.Packet.Yaw, e.Packet.Pitch);
+            this.MoveTo(e.Packet.X, e.Packet.Y - EyeGroundOffset, e.Packet.Z, e.Packet.Yaw, e.Packet.Pitch);
             this.OnGround = e.Packet.OnGround;
             this.Stance = e.Packet.Stance;
         }

--- a/Chraft/Client.Send.cs
+++ b/Chraft/Client.Send.cs
@@ -101,7 +101,7 @@ namespace Chraft
             PacketHandler.SendPacket(new PlayerPositionRotationPacket
             {
                 X = Position.X,
-                Y = Position.Y + 1,
+                Y = Position.Y + EyeGroundOffset,
                 Z = Position.Z,
                 Yaw = (float)Position.Yaw,
                 Pitch = (float)Position.Pitch,

--- a/Chraft/Client.cs
+++ b/Chraft/Client.cs
@@ -59,6 +59,8 @@ namespace Chraft
         /// </summary>
         public Logger Logger { get { return Server.Logger; } }
 
+        public const double EyeGroundOffset = 1.6200000047683716;
+
         /// <summary>
         /// Instantiates a new Client object.
         /// </summary>


### PR DESCRIPTION
The packet PlayerPositionRotation sends the current character Y + EyeGroundOffset, so when you read the packet EyeGroundOffset must be subtracted otherwise you'll set wrong positions.

_beginInAirY should be set to -1 everytime you touch the ground, otherwise when you fall but you don't jump it could be chosen the previous (higher) value, screwing the fall height calculation.
