### PR TITLE
Little command fixes and liquid's falling damage reduction

### DIFF
--- a/Chraft/Client.Actions.cs
+++ b/Chraft/Client.Actions.cs
@@ -121,7 +121,11 @@ namespace Chraft
             if (e.EventCanceled) return;
             command = e.Command;
             //End Event
-			string baseCommand = command.Substring(0, command.IndexOf(" "));
+
+            int argsPos = command.IndexOf(" ");
+            string baseCommand = command;
+            if (argsPos != -1)
+                baseCommand = command.Substring(0, command.IndexOf(" "));
 			if (!CanUseCommand(baseCommand))
             {
                 SendMessage("You do not have permission to use that command");

--- a/Chraft/Client.Persistence.cs
+++ b/Chraft/Client.Persistence.cs
@@ -10,7 +10,7 @@ namespace Chraft
     {
         private static XmlSerializer Xml = new XmlSerializer(typeof(ClientSurrogate));
         internal string Folder { get { return Settings.Default.PlayersFolder; } }
-        internal string DataFile { get { return Folder + "/" + Username + ".xml"; } }
+        internal string DataFile { get { return Folder + Path.DirectorySeparatorChar + Username + ".xml"; } }
         // TODO: Move a bunch of this to DataFile.cs
         private void Load()
         {

--- a/Chraft/Client.Recv.cs
+++ b/Chraft/Client.Recv.cs
@@ -97,7 +97,7 @@ namespace Chraft
                                 // If we are in water, count how many blocks above are also water
                                 BlockData.Blocks block = currentBlock;
                                 int waterCount = 0;
-                                while (block == BlockData.Blocks.Water)
+                                while (BlockData.IsLiquid(block))
                                 {
                                     waterCount++;
                                     block = (BlockData.Blocks)this.World.GetBlockId((int)this.Position.X, (int)this.Position.Y + waterCount, (int)this.Position.Z);

--- a/Chraft/Commands/CmdMute.cs
+++ b/Chraft/Commands/CmdMute.cs
@@ -17,16 +17,43 @@ namespace Chraft.Commands
                 return;
             }
 
-            Client[] muteClient = client.Server.GetClients(tokens[1]).ToArray();
-            if (muteClient.Length < 1)
+            Client[] matchedClients = client.Server.GetClients(tokens[1]).ToArray();
+            Client clientToMute = null;
+            if (matchedClients.Length < 1)
             {
                 client.SendMessage("Unknown Player");
                 return;
             }
-            bool clientMuted = muteClient[0].IsMuted;
-            muteClient[0].IsMuted = !clientMuted;
-            muteClient[0].SendMessage(clientMuted ? "You have been unmuted" : "You have been muted");
-            client.SendMessage(clientMuted ? tokens[1] + " has been unmuted" : tokens[1] + " has been muted");
+            else if (matchedClients.Length == 1)
+            {
+                clientToMute = matchedClients[0];
+            }
+            else if (matchedClients.Length > 1)
+            {
+                // We've got more than 1 client. I.e. "Test" and "Test123" for the "test" pattern.
+                // Looking for exact name match.
+                int exactMatchClient = -1;
+                for (int i = 0; i < matchedClients.Length; i++)
+                {
+                    if (matchedClients[i].DisplayName.ToLower() == tokens[1].ToLower())
+                        exactMatchClient = i;
+                }
+
+                // If we found the player with the exactly same name - he is our target
+                if (exactMatchClient != -1)
+                {
+                    clientToMute = matchedClients[exactMatchClient];
+                } else
+                {
+                    // We do not found a proper target and aren't going to randomly punish anyone
+                    client.SendMessage("More than one player found. Provide the exact name.");
+                    return;
+                }
+            }
+            bool clientMuted = clientToMute.IsMuted;
+            clientToMute.IsMuted = !clientMuted;
+            clientToMute.SendMessage(clientMuted ? "You have been unmuted" : "You have been muted");
+            client.SendMessage(clientMuted ? clientToMute.DisplayName + " has been unmuted" : clientToMute.DisplayName + " has been muted");
         }
 
         public void Help(Client client)

--- a/Chraft/Commands/CmdSetHealth.cs
+++ b/Chraft/Commands/CmdSetHealth.cs
@@ -12,7 +12,7 @@ namespace Chraft.Commands
 
         public void Use(Client client, string[] tokens)
         {
-            if (tokens.Length < 1)
+            if (tokens.Length < 2)
             {
                 SetHealth(client, 20);
                 return;
@@ -39,7 +39,7 @@ namespace Chraft.Commands
 
         public string Shortcut
         {
-            get { return ""; }
+            get { return "heal"; }
         }
 
         public CommandType Type

--- a/Chraft/World/WorldManager.cs
+++ b/Chraft/World/WorldManager.cs
@@ -30,7 +30,7 @@ namespace Chraft.World
         public Server Server { get; private set; }
         public Logger Logger { get { return Server.Logger; } }
         public string Name { get { return Settings.Default.DefaultWorldName; } }
-        public string Folder { get { return Settings.Default.WorldsFolder + "/" + Name; } }
+        public string Folder { get { return Settings.Default.WorldsFolder + Path.DirectorySeparatorChar + Name; } }
         public WeatherManager Weather { get; private set; }
 
         private readonly ChunkSet _Chunks;


### PR DESCRIPTION
Fixed couple very unimportant bugs in commands.

Fixed fall damage reduction. Actually, you will nearly always be on Still_Water block while the check is perfomed only against Water (flowing), so the damage will never be reduced. Now the check is perfomed against every liquid (flowing/still water/lava). Haven't tested lava dmg reduction in the original, but I'm sure it should reduce too.
