### PR TITLE
BigEndianStream enhancement and Service Installation

### DIFF
--- a/Chraft/Chraft.csproj
+++ b/Chraft/Chraft.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Entity\EntityBase.cs" />
     <Compile Include="Entity\EnumCreatureType.cs" />
     <Compile Include="Entity\ItemEntity.cs" />
+    <Compile Include="Net\StreamRole.cs" />
     <Compile Include="NibbleArray.cs" />
     <Compile Include="Permissions.cs" />
     <Compile Include="Properties\Settings.Designer.cs">

--- a/Chraft/Interfaces/PersistentContainerInterface.cs
+++ b/Chraft/Interfaces/PersistentContainerInterface.cs
@@ -64,7 +64,7 @@ namespace Chraft.Interfaces
             {
                 using (FileStream containerStream = File.Open(file, FileMode.Open, FileAccess.Read))
                 {
-                    using (Net.BigEndianStream bigEndian = new Net.BigEndianStream(containerStream))
+                    using (Net.BigEndianStream bigEndian = new Net.BigEndianStream(containerStream, StreamRole.Server))
                     {
                         for (int i = 0; i < itemStack.Length; i++)
                         {
@@ -127,7 +127,7 @@ namespace Chraft.Interfaces
                 {
                     using (FileStream fileStream = File.Create(file + ".tmp"))
                     {
-                        using (BigEndianStream bigEndian = new BigEndianStream(fileStream))
+                        using (BigEndianStream bigEndian = new BigEndianStream(fileStream, StreamRole.Server))
                         {
                             foreach (ItemStack stack in itemStack)
                             {

--- a/Chraft/Net/BigEndianStream.cs
+++ b/Chraft/Net/BigEndianStream.cs
@@ -13,6 +13,7 @@ namespace Chraft.Net
     public class BigEndianStream : Stream
     {
         public Stream Net { get; private set; }
+        public StreamRole Role { get; private set; }
 
         public override bool CanRead { get { return Net.CanRead; } }
         public override bool CanSeek { get { return Net.CanSeek; } }
@@ -20,9 +21,10 @@ namespace Chraft.Net
         public override long Length { get { return Net.Length; } }
         public override long Position { get { return Net.Position; } set { Net.Position = value; } }
 
-        public BigEndianStream(Stream stream)
+        public BigEndianStream(Stream stream, StreamRole role)
         {
             Net = stream;
+            Role = role;
         }
 
         public Packet ReadPacket()

--- a/Chraft/Net/PacketHandler.cs
+++ b/Chraft/Net/PacketHandler.cs
@@ -96,7 +96,7 @@ namespace Chraft.Net
         }
 
         public PacketHandler(Server server, TcpClient tcp)
-            : this(server, new BigEndianStream(tcp.GetStream()))
+            : this(server, new BigEndianStream(tcp.GetStream(), StreamRole.Server))
         {
         }
 

--- a/Chraft/Net/Packets/Packet.cs
+++ b/Chraft/Net/Packets/Packet.cs
@@ -361,9 +361,19 @@ namespace Chraft.Net.Packets
 
         public override void Read(BigEndianStream stream)
         {
-            X = stream.ReadDouble();
-            Stance = stream.ReadDouble();
-            Y = stream.ReadDouble();
+            //X,Y,Stance are in different order for Client->Server vs. Server->Client
+            if (stream.Role == StreamRole.Server)
+            {
+                X = stream.ReadDouble();
+                Stance = stream.ReadDouble();
+                Y = stream.ReadDouble();
+            }
+            else
+            {
+                X = stream.ReadDouble();
+                Y = stream.ReadDouble();
+                Stance = stream.ReadDouble();
+            }
             Z = stream.ReadDouble();
             Yaw = stream.ReadFloat();
             Pitch = stream.ReadFloat();
@@ -372,9 +382,19 @@ namespace Chraft.Net.Packets
 
         public override void Write(BigEndianStream stream)
         {
-            stream.Write(X);
-            stream.Write(Y);
-            stream.Write(Stance);
+            //X,Y,Stance are in different order for Client->Server vs. Server->Client
+            if (stream.Role == StreamRole.Server)
+            {
+                stream.Write(X);
+                stream.Write(Y);
+                stream.Write(Stance);
+            }
+            else
+            {
+                stream.Write(X);
+                stream.Write(Stance);
+                stream.Write(Y);
+            }
             stream.Write(Z);
             stream.Write(Yaw);
             stream.Write(Pitch);

--- a/Chraft/Net/StreamRole.cs
+++ b/Chraft/Net/StreamRole.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Chraft.Net
+{
+	/// <summary>
+	/// Specifies the role that this instance is playing in the communication.
+	/// Used for flipping packets that are different when sent from server -> client or client -> server.
+	/// </summary>
+	public enum StreamRole
+	{
+		/// <summary>
+		/// This stream represents the server-side of communication
+		/// </summary>
+		Server,
+		/// <summary>
+		/// This stream represents the client-side of communication
+		/// </summary>
+		Client
+	}
+}

--- a/ChraftServer/ProjectInstaller.cs
+++ b/ChraftServer/ProjectInstaller.cs
@@ -1,14 +1,23 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.Collections;
+using System.ComponentModel;
 
 
 namespace ChraftServer
 {
-	[RunInstaller(true)]
-	public partial class ProjectInstaller : System.Configuration.Install.Installer
-	{
-		public ProjectInstaller()
-		{
-			InitializeComponent();
-		}
-	}
+    [RunInstaller(true)]
+    public partial class ProjectInstaller : System.Configuration.Install.Installer
+    {
+        public ProjectInstaller()
+        {
+            InitializeComponent();
+        }
+
+        protected override void OnBeforeInstall(IDictionary savedState)
+        {
+            Context.Parameters["assemblypath"] = String.Format("\"{0}\" -service", Context.Parameters["assemblypath"]);
+            Console.WriteLine("Installing with Assembly Path: {0}", Context.Parameters["assemblypath"]);
+            base.OnBeforeInstall(savedState);
+        }
+    }
 }


### PR DESCRIPTION
- Add StreamRole enum.  Used to specify which end of the conversation the stream represents.  Player Position + Rotation packet has some fields that are flipped client->server vs server->client.  This will allow BigEndianStream to be used for communication as a client.
- Change to Service Installer to support need for adding -service parameter.
- Added -install and -uninstall command-line options to ChraftServer to simplify installation
