### PR TITLE
Develop

### DIFF
--- a/Chraft/Entity/Player.cs
+++ b/Chraft/Entity/Player.cs
@@ -668,7 +668,12 @@ namespace Chraft.Entity
 
         public void DropItem()
         {
-            Server.DropItem(this, Inventory.Slots[Inventory.ActiveSlot]);
+            var activeItemStack = Inventory.Slots[Inventory.ActiveSlot];
+            if (activeItemStack.Count > 0)
+            {
+                Server.DropItem(this, new ItemStack(activeItemStack.Type, 1, activeItemStack.Durability));
+                Inventory.RemoveItem(Inventory.ActiveSlot);
+            }
         }
 
 

--- a/Chraft/Net/Client.Recv.cs
+++ b/Chraft/Net/Client.Recv.cs
@@ -610,8 +610,6 @@ namespace Chraft.Net
                     break;
 
                 case PlayerDiggingPacket.DigAction.DropItem:
-                    var slot = player.Inventory.ActiveSlot;
-                    player.Inventory.RemoveItem(slot);
                     player.DropItem();
                     break;
             }


### PR DESCRIPTION
- When using q to drop a single item, the stack size of the item created in the world was the size of the item stack in the active slot.
- Using q with a active slot item with a stack size of 1 or 0 (no item) would crash the client because the server was creating items in the world with a stack size of 0 and a type of -1 (void item).
